### PR TITLE
Ensure proper handling of UTF-8 strings in HMAC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+- "5.0"
 - "4.2"
 - "4.1"
 - "4.0"

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ exports.validatePayload = function(rawBody, signature, secretKey) {
     // Replace bufferEq() once https://github.com/nodejs/node/issues/3043 is
     // resolved and the standard library implementation is available.
     var hmac = crypto.createHmac(algorithmAndHash[0], secretKey);
-    var computed = new Buffer(hmac.update(rawBody).digest('hex'));
+    var computed = new Buffer(hmac.update(rawBody, 'utf8').digest('hex'));
     var header = new Buffer(algorithmAndHash[1]);
     return bufferEq(computed, header);
   } catch (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ chai.use(chaiAsPromised);
 
 function makeSignature(payload, secret) {
   return 'sha1=' +
-    crypto.createHmac('sha1', secret).update(payload).digest('hex');
+    crypto.createHmac('sha1', secret).update(payload, 'utf8').digest('hex');
 }
 
 function check(done, cb) {
@@ -148,6 +148,16 @@ describe('PayloadValidator', function() {
       signature = 'foobar=' + algorithmAndHash[1];
       expect(validator.validatePayload(payload, signature, secret))
         .to.be.false;
+    });
+
+    it('should properly handle strings with UTF-8 characters', function() {
+      // Note the apostrophe in `it’s` is a UTF-8 smart quote.
+      var payload = '"description": "Guide to help agencies understand what ' +
+        'it’s like to work with 18F. ",';
+      signature = makeSignature(payload, secret);
+      expect(signature).to.equal(
+        'sha1=6364b3c77dc014e0226e541fc47615141e54428d');
+      expect(validator.validatePayload(payload, signature, secret)).to.be.true;
     });
   });
 


### PR DESCRIPTION
@wslack hit this bug when updates to 18F/partnership-playbook weren't
propagating to https://pages.18f.gov/partnership-playbook/. I found out that
the HMAC signature for the webhook didn't match what was sent by GitHub.

After verifying the exact same inputs and computing the GitHub version of the
signature locally in a Ruby script, I eventually noticed that adding the
'utf8' encoding specifier to Hmac.update() solved the problem. I then was able
to identify that the trouble-making part of the payload was an instance of the
string `it’s` where the apostrophe is a UTF-8 smart quote character.

This isn't super-duper urgent, but would appreciate a relatively swift merge from @arowla, @jeremiak, @afeld, or some other kind-hearted volunteer.
